### PR TITLE
Add LeadMessage entity and CRUD endpoints

### DIFF
--- a/lawyer.api.leads.application/Common/MappingProfiles/LeadMessageProfile.cs
+++ b/lawyer.api.leads.application/Common/MappingProfiles/LeadMessageProfile.cs
@@ -1,0 +1,18 @@
+using AutoMapper;
+using lawyer.api.leads.application.DTO;
+using lawyer.api.leads.application.UseCases.LeadMessage.Create;
+using lawyer.api.leads.application.UseCases.LeadMessage.Update;
+using lawyer.api.leads.domain;
+
+namespace lawyer.api.leads.application.Common.MappingProfiles;
+
+public class LeadMessageProfile : Profile
+{
+    public LeadMessageProfile()
+    {
+        CreateMap<LeadMessageDto, LeadMessage>().ReverseMap();
+        CreateMap<CreateLeadMessageCommand, LeadMessage>().ReverseMap();
+        CreateMap<UpdateLeadMessageCommand, LeadMessage>().ReverseMap();
+    }
+}
+

--- a/lawyer.api.leads.application/Contracts/Interfaces/Persistence/LeadMessage/ILeadMessageCommandRepository.cs
+++ b/lawyer.api.leads.application/Contracts/Interfaces/Persistence/LeadMessage/ILeadMessageCommandRepository.cs
@@ -1,0 +1,8 @@
+using lawyer.api.leads.application.Contracts.Interfaces.Persistence.Common;
+
+namespace lawyer.api.leads.application.Contracts.Interfaces.Persistence.LeadMessage;
+
+public interface ILeadMessageCommandRepository : ICommandRepository<domain.LeadMessage>
+{
+}
+

--- a/lawyer.api.leads.application/Contracts/Interfaces/Persistence/LeadMessage/ILeadMessageQueryRepository.cs
+++ b/lawyer.api.leads.application/Contracts/Interfaces/Persistence/LeadMessage/ILeadMessageQueryRepository.cs
@@ -1,0 +1,8 @@
+using lawyer.api.leads.application.Contracts.Interfaces.Persistence.Common;
+
+namespace lawyer.api.leads.application.Contracts.Interfaces.Persistence.LeadMessage;
+
+public interface ILeadMessageQueryRepository : IQueryRepository<domain.LeadMessage>
+{
+}
+

--- a/lawyer.api.leads.application/DTO/LeadMessageDto.cs
+++ b/lawyer.api.leads.application/DTO/LeadMessageDto.cs
@@ -1,0 +1,11 @@
+namespace lawyer.api.leads.application.DTO;
+
+public class LeadMessageDto
+{
+    public Guid Id { get; set; }
+    public Guid IdLead { get; set; }
+    public Guid IdUser { get; set; }
+    public int UserType { get; set; }
+    public string Text { get; set; } = string.Empty;
+}
+

--- a/lawyer.api.leads.application/UseCases/LeadMessage/Create/CreateLeadMessageCommand.cs
+++ b/lawyer.api.leads.application/UseCases/LeadMessage/Create/CreateLeadMessageCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+
+namespace lawyer.api.leads.application.UseCases.LeadMessage.Create;
+
+public class CreateLeadMessageCommand : IRequest<Guid>
+{
+    public Guid IdLead { get; set; }
+    public Guid IdUser { get; set; }
+    public int UserType { get; set; }
+    public string Text { get; set; } = string.Empty;
+}
+

--- a/lawyer.api.leads.application/UseCases/LeadMessage/Create/CreateLeadMessageCommandHandler.cs
+++ b/lawyer.api.leads.application/UseCases/LeadMessage/Create/CreateLeadMessageCommandHandler.cs
@@ -1,0 +1,27 @@
+using AutoMapper;
+using lawyer.api.leads.application.Contracts.Interfaces.Persistence.LeadMessage;
+using MediatR;
+
+namespace lawyer.api.leads.application.UseCases.LeadMessage.Create;
+
+public class CreateLeadMessageCommandHandler : IRequestHandler<CreateLeadMessageCommand, Guid>
+{
+    private readonly ILeadMessageCommandRepository _command;
+    private readonly IMapper _mapper;
+
+    public CreateLeadMessageCommandHandler(
+        ILeadMessageCommandRepository command,
+        IMapper mapper)
+    {
+        _command = command;
+        _mapper = mapper;
+    }
+
+    public async Task<Guid> Handle(CreateLeadMessageCommand request, CancellationToken cancellationToken)
+    {
+        var entity = _mapper.Map<domain.LeadMessage>(request);
+        await _command.CreateAsync(entity);
+        return entity.Id;
+    }
+}
+

--- a/lawyer.api.leads.application/UseCases/LeadMessage/Delete/DeleteLeadMessageCommand.cs
+++ b/lawyer.api.leads.application/UseCases/LeadMessage/Delete/DeleteLeadMessageCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace lawyer.api.leads.application.UseCases.LeadMessage.Delete;
+
+public class DeleteLeadMessageCommand : IRequest<Unit>
+{
+    public Guid Id { get; set; }
+}
+

--- a/lawyer.api.leads.application/UseCases/LeadMessage/Delete/DeleteLeadMessageCommandHandler.cs
+++ b/lawyer.api.leads.application/UseCases/LeadMessage/Delete/DeleteLeadMessageCommandHandler.cs
@@ -1,0 +1,24 @@
+using lawyer.api.leads.application.Contracts.Interfaces.Persistence.LeadMessage;
+using MediatR;
+
+namespace lawyer.api.leads.application.UseCases.LeadMessage.Delete;
+
+public class DeleteLeadMessageCommandHandler : IRequestHandler<DeleteLeadMessageCommand, Unit>
+{
+    private readonly ILeadMessageCommandRepository _command;
+    private readonly ILeadMessageQueryRepository _query;
+
+    public DeleteLeadMessageCommandHandler(ILeadMessageCommandRepository command, ILeadMessageQueryRepository query)
+    {
+        _command = command;
+        _query = query;
+    }
+
+    public async Task<Unit> Handle(DeleteLeadMessageCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        await _command.DeleteAsync(entity);
+        return Unit.Value;
+    }
+}
+

--- a/lawyer.api.leads.application/UseCases/LeadMessage/GetAll/GetAllLeadMessageQuery.cs
+++ b/lawyer.api.leads.application/UseCases/LeadMessage/GetAll/GetAllLeadMessageQuery.cs
@@ -1,0 +1,9 @@
+using lawyer.api.leads.application.DTO;
+using MediatR;
+
+namespace lawyer.api.leads.application.UseCases.LeadMessage.GetAll;
+
+public class GetAllLeadMessageQuery : IRequest<List<LeadMessageDto>>, IRequest<LeadMessageDto>
+{
+}
+

--- a/lawyer.api.leads.application/UseCases/LeadMessage/GetAll/GetAllLeadMessageQueryHandler.cs
+++ b/lawyer.api.leads.application/UseCases/LeadMessage/GetAll/GetAllLeadMessageQueryHandler.cs
@@ -1,0 +1,27 @@
+using AutoMapper;
+using lawyer.api.leads.application.Contracts.Interfaces.Persistence.LeadMessage;
+using lawyer.api.leads.application.DTO;
+using MediatR;
+
+namespace lawyer.api.leads.application.UseCases.LeadMessage.GetAll;
+
+public class GetAllLeadMessageQueryHandler : IRequestHandler<GetAllLeadMessageQuery, List<LeadMessageDto>>
+{
+    private readonly ILeadMessageQueryRepository _query;
+    private readonly IMapper _mapper;
+
+    public GetAllLeadMessageQueryHandler(
+        IMapper mapper,
+        ILeadMessageQueryRepository query)
+    {
+        _mapper = mapper;
+        _query = query;
+    }
+
+    public async Task<List<LeadMessageDto>> Handle(GetAllLeadMessageQuery request, CancellationToken cancellationToken)
+    {
+        var entities = await _query.GetAllAsync();
+        return _mapper.Map<List<LeadMessageDto>>(entities);
+    }
+}
+

--- a/lawyer.api.leads.application/UseCases/LeadMessage/GetById/GetByIdLeadMessageQuery.cs
+++ b/lawyer.api.leads.application/UseCases/LeadMessage/GetById/GetByIdLeadMessageQuery.cs
@@ -1,0 +1,15 @@
+using lawyer.api.leads.application.DTO;
+using MediatR;
+
+namespace lawyer.api.leads.application.UseCases.LeadMessage.GetById;
+
+public class GetByIdLeadMessageQuery : IRequest<LeadMessageDto>
+{
+    public GetByIdLeadMessageQuery(Guid id)
+    {
+        Id = id;
+    }
+
+    public Guid Id { get; set; }
+}
+

--- a/lawyer.api.leads.application/UseCases/LeadMessage/GetById/GetByIdLeadMessageQueryHandler.cs
+++ b/lawyer.api.leads.application/UseCases/LeadMessage/GetById/GetByIdLeadMessageQueryHandler.cs
@@ -1,0 +1,27 @@
+using AutoMapper;
+using lawyer.api.leads.application.Contracts.Interfaces.Persistence.LeadMessage;
+using lawyer.api.leads.application.DTO;
+using MediatR;
+
+namespace lawyer.api.leads.application.UseCases.LeadMessage.GetById;
+
+public class GetByIdLeadMessageQueryHandler : IRequestHandler<GetByIdLeadMessageQuery, LeadMessageDto>
+{
+    private readonly IMapper _mapper;
+    private readonly ILeadMessageQueryRepository _query;
+
+    public GetByIdLeadMessageQueryHandler(
+        IMapper mapper,
+        ILeadMessageQueryRepository query)
+    {
+        _mapper = mapper;
+        _query = query;
+    }
+
+    public async Task<LeadMessageDto> Handle(GetByIdLeadMessageQuery request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        return _mapper.Map<LeadMessageDto>(entity);
+    }
+}
+

--- a/lawyer.api.leads.application/UseCases/LeadMessage/Update/UpdateLeadMessageCommand.cs
+++ b/lawyer.api.leads.application/UseCases/LeadMessage/Update/UpdateLeadMessageCommand.cs
@@ -1,0 +1,13 @@
+using MediatR;
+
+namespace lawyer.api.leads.application.UseCases.LeadMessage.Update;
+
+public class UpdateLeadMessageCommand : IRequest<Guid>
+{
+    public Guid Id { get; set; }
+    public Guid IdLead { get; set; }
+    public Guid IdUser { get; set; }
+    public int UserType { get; set; }
+    public string Text { get; set; } = string.Empty;
+}
+

--- a/lawyer.api.leads.application/UseCases/LeadMessage/Update/UpdateLeadMessageCommandHandler.cs
+++ b/lawyer.api.leads.application/UseCases/LeadMessage/Update/UpdateLeadMessageCommandHandler.cs
@@ -1,0 +1,34 @@
+using lawyer.api.leads.application.Contracts.Interfaces.Persistence.LeadMessage;
+using MediatR;
+
+namespace lawyer.api.leads.application.UseCases.LeadMessage.Update;
+
+public class UpdateLeadMessageCommandHandler : IRequestHandler<UpdateLeadMessageCommand, Guid>
+{
+    private readonly ILeadMessageCommandRepository _command;
+    private readonly ILeadMessageQueryRepository _query;
+
+    public UpdateLeadMessageCommandHandler(
+        ILeadMessageCommandRepository command,
+        ILeadMessageQueryRepository query)
+    {
+        _command = command;
+        _query = query;
+    }
+
+    public async Task<Guid> Handle(UpdateLeadMessageCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        if (entity == null) throw new KeyNotFoundException($"The LeadMessage with ID {request.Id} does not exist.");
+
+        entity.IdLead = request.IdLead;
+        entity.IdUser = request.IdUser;
+        entity.UserType = request.UserType;
+        entity.Text = request.Text;
+        entity.DateModified = DateTime.UtcNow;
+
+        await _command.UpdateAsync(entity);
+        return entity.Id;
+    }
+}
+

--- a/lawyer.api.leads.datastore.mssql/DatabaseContext/LawyersContext.cs
+++ b/lawyer.api.leads.datastore.mssql/DatabaseContext/LawyersContext.cs
@@ -15,6 +15,7 @@ public class LawyersContext : DbContext
     public DbSet<CountryEntity> Countries { get; set; }
     public DbSet<LeadStateEntity> LeadStates { get; set; }
     public DbSet<LeadEntity> Leads { get; set; }
+    public DbSet<LeadMessageEntity> LeadMessages { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/lawyer.api.leads.datastore.mssql/Model/LeadMessage.cs
+++ b/lawyer.api.leads.datastore.mssql/Model/LeadMessage.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using lawyer.api.leads.datastore.mssql.Model.Common;
+
+namespace lawyer.api.leads.datastore.mssql.Model;
+
+[Table("LeadMessages", Schema = "leads")]
+public class LeadMessageEntity : EFEntity
+{
+    public Guid IdLead { get; set; }
+    public Guid IdUser { get; set; }
+    public int UserType { get; set; }
+    public string Text { get; set; }
+
+    [ForeignKey(nameof(IdLead))]
+    public LeadEntity Lead { get; set; }
+}
+

--- a/lawyer.api.leads.datastore.mssql/Model/MappingProfile/ApplicationMappingProfile.cs
+++ b/lawyer.api.leads.datastore.mssql/Model/MappingProfile/ApplicationMappingProfile.cs
@@ -13,5 +13,6 @@ public class ApplicationMappingProfile : Profile
         CreateMap<Country, CountryEntity>().ReverseMap();
         CreateMap<LeadState, LeadStateEntity>().ReverseMap();
         CreateMap<Lead, LeadEntity>().ReverseMap();
+        CreateMap<LeadMessage, LeadMessageEntity>().ReverseMap();
     }
 }

--- a/lawyer.api.leads.datastore.mssql/PersistenceServiceRegistration.cs
+++ b/lawyer.api.leads.datastore.mssql/PersistenceServiceRegistration.cs
@@ -3,6 +3,7 @@ using lawyer.api.leads.application.Contracts.Interfaces.Persistence.City;
 using lawyer.api.leads.application.Contracts.Interfaces.Persistence.Country;
 using lawyer.api.leads.application.Contracts.Interfaces.Persistence.LeadState;
 using lawyer.api.leads.application.Contracts.Interfaces.Persistence.Lead;
+using lawyer.api.leads.application.Contracts.Interfaces.Persistence.LeadMessage;
 using lawyer.api.leads.datastore.mssql.DatabaseContext;
 using lawyer.api.leads.datastore.mssql.Model.MappingProfile;
 using lawyer.api.leads.datastore.mssql.Repositories.Example;
@@ -10,6 +11,7 @@ using lawyer.api.leads.datastore.mssql.Repositories.City;
 using lawyer.api.leads.datastore.mssql.Repositories.Country;
 using lawyer.api.leads.datastore.mssql.Repositories.LeadState;
 using lawyer.api.leads.datastore.mssql.Repositories.Lead;
+using lawyer.api.leads.datastore.mssql.Repositories.LeadMessage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,6 +36,8 @@ public static class PersistenceServiceRegistration
         services.AddScoped<ILeadStateQueryRepository, LeadStateQueryRepository>();
         services.AddScoped<ILeadCommandRepository, LeadCommandRepository>();
         services.AddScoped<ILeadQueryRepository, LeadQueryRepository>();
+        services.AddScoped<ILeadMessageCommandRepository, LeadMessageCommandRepository>();
+        services.AddScoped<ILeadMessageQueryRepository, LeadMessageQueryRepository>();
 
         return services;
     }

--- a/lawyer.api.leads.datastore.mssql/Repositories/LeadMessage/LeadMessageCommandRepository.cs
+++ b/lawyer.api.leads.datastore.mssql/Repositories/LeadMessage/LeadMessageCommandRepository.cs
@@ -1,0 +1,18 @@
+using AutoMapper;
+using lawyer.api.leads.application.Contracts.Interfaces.Persistence.LeadMessage;
+using lawyer.api.leads.datastore.mssql.DatabaseContext;
+using lawyer.api.leads.datastore.mssql.Model;
+using lawyer.api.leads.datastore.mssql.Repositories.Common;
+
+namespace lawyer.api.leads.datastore.mssql.Repositories.LeadMessage;
+
+public class LeadMessageCommandRepository : CommandRepository<domain.LeadMessage, LeadMessageEntity>, ILeadMessageCommandRepository
+{
+    private readonly IMapper _mapper;
+
+    public LeadMessageCommandRepository(LawyersContext dbContext, IMapper mapper) : base(dbContext, mapper)
+    {
+        _mapper = mapper;
+    }
+}
+

--- a/lawyer.api.leads.datastore.mssql/Repositories/LeadMessage/LeadMessageQueryRepository.cs
+++ b/lawyer.api.leads.datastore.mssql/Repositories/LeadMessage/LeadMessageQueryRepository.cs
@@ -1,0 +1,18 @@
+using AutoMapper;
+using lawyer.api.leads.application.Contracts.Interfaces.Persistence.LeadMessage;
+using lawyer.api.leads.datastore.mssql.DatabaseContext;
+using lawyer.api.leads.datastore.mssql.Model;
+using lawyer.api.leads.datastore.mssql.Repositories.Common;
+
+namespace lawyer.api.leads.datastore.mssql.Repositories.LeadMessage;
+
+public class LeadMessageQueryRepository : QueryRepository<domain.LeadMessage, LeadMessageEntity>, ILeadMessageQueryRepository
+{
+    private readonly IMapper _mapper;
+
+    public LeadMessageQueryRepository(LawyersContext dbContext, IMapper mapper) : base(dbContext, mapper)
+    {
+        _mapper = mapper;
+    }
+}
+

--- a/lawyer.api.leads.domain/LeadMessage.cs
+++ b/lawyer.api.leads.domain/LeadMessage.cs
@@ -1,0 +1,12 @@
+using lawyer.api.leads.domain.Common;
+
+namespace lawyer.api.leads.domain;
+
+public class LeadMessage : BaseEntity
+{
+    public Guid IdLead { get; set; }
+    public Guid IdUser { get; set; }
+    public int UserType { get; set; }
+    public string Text { get; set; } = string.Empty;
+}
+

--- a/lawyer.api.leads.webapi/Controllers/LeadMessageController.cs
+++ b/lawyer.api.leads.webapi/Controllers/LeadMessageController.cs
@@ -1,0 +1,71 @@
+using lawyer.api.leads.application.DTO;
+using lawyer.api.leads.application.UseCases.LeadMessage.Create;
+using lawyer.api.leads.application.UseCases.LeadMessage.Delete;
+using lawyer.api.leads.application.UseCases.LeadMessage.GetAll;
+using lawyer.api.leads.application.UseCases.LeadMessage.GetById;
+using lawyer.api.leads.application.UseCases.LeadMessage.Update;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace lawyer.api.leads.webapi.Controllers;
+
+[Authorize]
+[ApiController]
+[Route("api/[controller]")]
+public class LeadMessageController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public LeadMessageController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<LeadMessageDto>>> Get()
+    {
+        var entities = await _mediator.Send(new GetAllLeadMessageQuery());
+        return Ok(entities);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<LeadMessageDto>> Get(Guid id)
+    {
+        var entity = await _mediator.Send(new GetByIdLeadMessageQuery(id));
+        return Ok(entity);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(201)]
+    [ProducesResponseType(400)]
+    public async Task<ActionResult> Post([FromBody] CreateLeadMessageCommand command)
+    {
+        var id = await _mediator.Send(command);
+        var url = Url.Action(nameof(Get), new { id });
+        return Created(url, id);
+    }
+
+    [HttpPut]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(400)]
+    public async Task<ActionResult> Put([FromBody] UpdateLeadMessageCommand command)
+    {
+        if (command.Id == Guid.Empty)
+            return BadRequest("The provided ID is not valid.");
+
+        var updatedId = await _mediator.Send(command);
+        return Ok(updatedId);
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(404)]
+    public async Task<ActionResult> Delete(Guid id)
+    {
+        var command = new DeleteLeadMessageCommand { Id = id };
+        await _mediator.Send(command);
+        return NoContent();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add LeadMessage domain entity with DTO and mappings
- implement repositories and use cases for LeadMessage CRUD
- expose LeadMessage CRUD endpoints in Web API

## Testing
- `dotnet build lawyer.api.leads.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b896a0f31483238c23bae96fc2be4c